### PR TITLE
Add baseline vault dockerfiles for inclusion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ packer (full)
 
 packer (light)
 [![](https://badge.imagelayers.io/timfallmk/packer-auto:light.svg)](https://imagelayers.io/?images=timfallmk/packer-auto:light 'Get your own badge on imagelayers.io')
+
+vault (full)
+[![](https://badge.imagelayers.io/hashicorp/vault:latest.svg)](https://imagelayers.io/?images=hashicorp/vault:latest 'Get your own badge on imagelayers.io')
+
+vault (light)
+[![](https://badge.imagelayers.io/hashicorp/vault:light.svg)](https://imagelayers.io/?images=hashicorp/vault:light 'Get your own badge on imagelayers.io')

--- a/vault/Dockerfile
+++ b/vault/Dockerfile
@@ -1,0 +1,2 @@
+FROM golang:onbuild
+MAINTAINER "Tim Fall <tim@hashicorp.com>"

--- a/vault/Dockerfile-full
+++ b/vault/Dockerfile-full
@@ -1,0 +1,16 @@
+FROM golang:alpine
+MAINTAINER "Tim Fall <tim@hashicorp.com>"
+
+RUN apk add --update git bash
+RUN go get github.com/mitchellh/gox
+RUN go get github.com/tools/godep
+RUN go get github.com/hashicorp/vault
+
+WORKDIR $GOPATH/src/github.com/hashicorp/vault
+
+RUN godep restore -v .../.
+
+RUN /bin/bash scripts/build.sh
+
+WORKDIR $GOPATH
+ENTRYPOINT ["bin/vault"]

--- a/vault/Dockerfile-light
+++ b/vault/Dockerfile-light
@@ -1,0 +1,17 @@
+FROM alpine:latest
+MAINTAINER "Tim Fall <tim@hashicorp.com>"
+
+ENV VAULT_VERSION=0.5.2
+ENV VAULT_SHA256SUM=7517b21d2c709e661914fbae1f6bf3622d9347b0fe9fc3334d78a01d1e1b4ec2
+
+RUN apk add --update git bash wget
+
+ADD https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip ./
+ADD https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_SHA256SUMS ./
+
+RUN sed -i '/vault_${VAULT_VERSION}_linux_amd64.zip/!d' vault_${VAULT_VERSION}_SHA256SUMS
+RUN sha256sum -cs vault_${VAULT_VERSION}_SHA256SUMS
+RUN unzip vault_${VAULT_VERSION}_linux_amd64.zip
+RUN rm -f vault_${VAULT_VERSION}_linux_amd64.zip
+
+ENTRYPOINT ["/vault"]

--- a/vault/README.md
+++ b/vault/README.md
@@ -1,0 +1,20 @@
+# vault Docker Container
+### Usage
+This repository automatically builds containers for using the [`vault`](https://vault.io) command line program. It contains two distinct varieties of build, a `light` version, which just contains the binary, and a `full` version while compiles the binary from source inside the container before exposing it for use. Which you want will depend on use.
+
+##### `light` (default)
+
+The `light` version of this container will copy the current stable version of the binary into the container, and set it for use as the default entrypoint. This will be the best option for most uses, and if you are just looking to run the binary from a container. The `latest` tag also points to this version.
+
+You can use this version with the following:
+```shell
+docker run -i -t hashicorp/vault:light <command>
+```
+
+##### `full`
+The `full` version of this container contains all of the source code found in the parent [repository](https://github.com/hashicorp/vault). Using [Google's official `golang` image](https://hub.docker.com/_/golang/) as a base, this container will copy the source from the `master` branch, build the binary, and expose it for running. Since the build is done on [Docker Hub](https://hub.docker.com/r/hashicorp), the container is ready for use. Because all build artifacts are included, it should be quite a bit larger than the `light` image. This version of the container is useful for development or debugging.
+
+You can use this version with the following:
+```shell
+docker run -i -t hashicorp/vault:full <command>
+```


### PR DESCRIPTION
Got excited at the prospect of having official hashicorp images for vault. I just followed the original pattern thus far. 

Eventually is the plan to support multiple versions so the folder structure would be?

vault
       0.5
             dockerfile
       0.6
             dockerfile