### PR TITLE
update Docker-full to clone the repo and build from the TERRAFORM_VERSION tag

### DIFF
--- a/terraform/Dockerfile-full
+++ b/terraform/Dockerfile-full
@@ -7,13 +7,10 @@ RUN apk add --update git bash
 
 ENV TF_DEV=true
 
-RUN mkdir -p $GOPATH/src/github.com/hashicorp
-WORKDIR $GOPATH/src/github.com/hashicorp
-RUN git clone https://github.com/hashicorp/terraform.git
-
 WORKDIR $GOPATH/src/github.com/hashicorp/terraform
-RUN git checkout v${TERRAFORM_VERSION}
-RUN /bin/bash scripts/build.sh
+RUN git clone https://github.com/hashicorp/terraform.git ./ && \
+    git checkout v${TERRAFORM_VERSION} && \
+    /bin/bash scripts/build.sh
 
 WORKDIR $GOPATH
 ENTRYPOINT ["bin/terraform"]

--- a/terraform/Dockerfile-full
+++ b/terraform/Dockerfile-full
@@ -13,4 +13,4 @@ RUN git clone https://github.com/hashicorp/terraform.git ./ && \
     /bin/bash scripts/build.sh
 
 WORKDIR $GOPATH
-ENTRYPOINT ["bin/terraform"]
+ENTRYPOINT ["terraform"]

--- a/terraform/Dockerfile-full
+++ b/terraform/Dockerfile-full
@@ -1,16 +1,18 @@
 FROM golang:alpine
 MAINTAINER "HashiCorp Terraform Team <terraform@hashicorp.com>"
 
+ENV TERRAFORM_VERSION=0.7.2
+
 RUN apk add --update git bash
-RUN go get github.com/tools/godep
-RUN go get github.com/hashicorp/terraform
-
-WORKDIR $GOPATH/src/github.com/hashicorp/terraform
-
-RUN godep restore -v .../.
 
 ENV TF_DEV=true
 
+RUN mkdir -p $GOPATH/src/github.com/hashicorp
+WORKDIR $GOPATH/src/github.com/hashicorp
+RUN git clone https://github.com/hashicorp/terraform.git
+
+WORKDIR $GOPATH/src/github.com/hashicorp/terraform
+RUN git checkout v${TERRAFORM_VERSION}
 RUN /bin/bash scripts/build.sh
 
 WORKDIR $GOPATH


### PR DESCRIPTION
This should update our `Dockerfile-Full` to build Terraform based on the release version, but cloning the repo, checking out the tag, and running `scripts/build.sh`. The current version relies on `godep`, which we no longer use. 

I am at best a Docker novice, so any guidance on improving this is welcome 😄 