### PR TITLE
Packer:light - add volume & workdir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile*

--- a/packer/Dockerfile-light
+++ b/packer/Dockerfile-light
@@ -14,4 +14,10 @@ RUN sha256sum -cs packer_${PACKER_VERSION}_SHA256SUMS
 RUN unzip packer_${PACKER_VERSION}_linux_amd64.zip -d /bin
 RUN rm -f packer_${PACKER_VERSION}_linux_amd64.zip
 
+RUN mkdir /packer
+
+VOLUME ["/packer"]
+
+WORKDIR /packer
+
 ENTRYPOINT ["/bin/packer"]

--- a/packer/README.md
+++ b/packer/README.md
@@ -7,11 +7,20 @@ This repository automatically builds containers for using the [`packer`](https:/
 The `light` version of this container will copy the current stable version of the binary into the container, and set it for use as the default entrypoint. This will be the best option for most uses, and if you are just looking to run the binary from a container. The `latest` tag also points to this version.
 
 You can use this version with the following:
+
 ```shell
-docker run -i -t hashicorp/packer:light <command>
+docker run -it --rm -v `pwd`:/packer hashicorp/packer:light <command>
 ```
 
+`packer` execution is run from the `/packer` container directory. Build output will
+be relative to this directory. Mount a host volume to store builds on your host relative
+to the mounted directory. Used in this way, the packer:light image mimics a native `packer`
+installation.
+
+For more information, check out the Docker docs: [Mount a host directory as a data volume](https://docs.docker.com/engine/tutorials/dockervolumes/#mount-a-host-directory-as-a-data-volume).
+
 ##### `full`
+
 The `full` version of this container contains all of the source code found in the parent [repository](https://github.com/mitchellh/packer). Using [Google's official `golang` image](https://hub.docker.com/_/golang/) as a base, this container will copy the source from the `master` branch, build the binary, and expose it for running. Since the build is done on [Docker Hub](https://hub.docker.com/r/hashicorp), the container is ready for use. Because all build artifacts are included, it should be quite a bit larger than the `light` image. This version of the container is useful for development or debugging.
 
 You can use this version with the following:


### PR DESCRIPTION
This MR adds a container volume at `/packer`, and sets that as the `WORKDIR`. This addition:
- standardizes the interpolation of `{{template_dir}}` from packer templates
- mimics the operation/execution of a native `packer` installation
- allows for post-execution cleanup of the packer container using `--rm` flag
  - no need for dangling containers/unintended side-effects to exist on the host
  - leaves the system just as clean as the native `packer` binary 

I also added docs that should help clarify the need to mount the hosts's working directory when running the `packer:light` container.

I also added a `.dockerignore` that will keep other Dockerfiles from cluttering the built images.

This Merge Request closes #8
