### PR TITLE
Update terraform image to 0.7.4

### DIFF
--- a/terraform/Dockerfile-full
+++ b/terraform/Dockerfile-full
@@ -1,7 +1,7 @@
 FROM golang:alpine
 MAINTAINER "HashiCorp Terraform Team <terraform@hashicorp.com>"
 
-ENV TERRAFORM_VERSION=0.7.2
+ENV TERRAFORM_VERSION=0.7.4
 
 RUN apk add --update git bash
 


### PR DESCRIPTION
not sure if this was on purpose but the `light` image was on a newer version than `full`