### PR TITLE
Update Dockerfile-full

### DIFF
--- a/packer/Dockerfile-full
+++ b/packer/Dockerfile-full
@@ -5,10 +5,11 @@ RUN apk add --update git bash
 RUN go get github.com/mitchellh/gox
 RUN go get github.com/tools/godep
 RUN go get github.com/mitchellh/packer
+RUN go get github.com/kardianos/govendor
 
 WORKDIR $GOPATH/src/github.com/mitchellh/packer
 
-RUN godep restore .../.
+RUN govendor fetch packer
 
 RUN /bin/bash scripts/build.sh
 


### PR DESCRIPTION
Use govendor instead of godeps so packer can still be built (see: https://github.com/mitchellh/packer/commit/02029503870181b139dee74faa4e270b6e32f5e1)

Fixes https://github.com/hashicorp/docker-hub-images/issues/20