### PR TITLE
Fixbuildpacker

### DIFF
--- a/packer/Dockerfile-full
+++ b/packer/Dockerfile-full
@@ -1,15 +1,13 @@
 FROM golang:alpine
-MAINTAINER "Tim Fall <tim@hashicorp.com>"
+MAINTAINER "Matt Hooker <mhooker@hashicorp.com>"
+
+ENV PACKER_DEV=1
 
 RUN apk add --update git bash
 RUN go get github.com/mitchellh/gox
-RUN go get github.com/tools/godep
 RUN go get github.com/mitchellh/packer
-RUN go get github.com/kardianos/govendor
 
 WORKDIR $GOPATH/src/github.com/mitchellh/packer
-
-RUN govendor fetch packer
 
 RUN /bin/bash scripts/build.sh
 

--- a/packer/Dockerfile-full
+++ b/packer/Dockerfile-full
@@ -5,10 +5,11 @@ RUN apk add --update git bash
 RUN go get github.com/mitchellh/gox
 RUN go get github.com/tools/godep
 RUN go get github.com/mitchellh/packer
+RUN go get github.com/kardianos/govendor
 
 WORKDIR $GOPATH/src/github.com/mitchellh/packer
 
-RUN godep restore .../.
+RUN govendor fetch packer
 
 RUN /bin/bash scripts/build.sh
 


### PR DESCRIPTION
replaces #21 
closes #20 

we don't actually need to install or run govendor since we vendor our dependencies

also set `PACKER_DEV=1` so we only build for the alpine linux environment