### PR TITLE
Fix Packer (full) syntax error and missing entrypoint

### DIFF
--- a/packer/Dockerfile-full
+++ b/packer/Dockerfile-full
@@ -9,7 +9,8 @@ RUN go get github.com/mitchellh/packer
 
 WORKDIR $GOPATH/src/github.com/mitchellh/packer
 
-RUN /bin/bash scripts/build.sh
+RUN /bin/bash scripts/build.sh && \
+  cp /go/bin/packer /bin/
 
 WORKDIR $GOPATH
-ENTRYPOINT ["bin/packer"]
+ENTRYPOINT ["/bin/packer"]


### PR DESCRIPTION
The packer binary wasn't copied to the desired location.  Moreover, the entrypoint was missing the leading slash.