### PR TITLE
terraform/resource: Add an image terraform-resource based on terraform full for scripting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ packer (full)
 
 packer (light)
 [![](https://badge.imagelayers.io/timfallmk/packer-auto:light.svg)](https://imagelayers.io/?images=timfallmk/packer-auto:light 'Get your own badge on imagelayers.io')
+
+packer (resource)
+[![](https://badge.imagelayers.io/timfallmk/packer-auto:resource.svg)](https://imagelayers.io/?images=timfallmk/packer-auto:resource 'Get your own badge on imagelayers.io')

--- a/terraform/Dockerfile-resource
+++ b/terraform/Dockerfile-resource
@@ -1,0 +1,5 @@
+FROM hashicorp/terraform:full
+
+RUN apk add --update openssh
+
+ENTRYPOINT []

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -18,3 +18,11 @@ You can use this version with the following:
 ```shell
 docker run -i -t hashicorp/terraform:full <command>
 ```
+
+##### `resource`
+The `resource` version of this container is a clone of the full version without entry point.
+
+You can use this version with the following:
+```shell
+docker run -i -t hashicorp/terraform:resource terraform <command> && terraform <command>
+```


### PR DESCRIPTION
Hey,

Thank you for this image but I need another kind of terraform image. I need to execute some bash scripts through the container (mainly because of [gitlab-ci](https://gitlab.com/gitlab-org/gitlab-ci-multi-runner/blob/master/docs/executors/docker.md#the-entrypoint)).

Added dependency over openssh to be able to perform a `terraform get` over a git repository (ssh).