### PR TITLE
Add openssl package

### DIFF
--- a/packer/Dockerfile-full
+++ b/packer/Dockerfile-full
@@ -3,7 +3,7 @@ MAINTAINER "Matt Hooker <mhooker@hashicorp.com>"
 
 ENV PACKER_DEV=1
 
-RUN apk add --update git bash
+RUN apk add --update git bash openssl
 RUN go get github.com/mitchellh/gox
 RUN go get github.com/hashicorp/packer
 

--- a/packer/Dockerfile-light
+++ b/packer/Dockerfile-light
@@ -4,7 +4,7 @@ MAINTAINER "Matt Hooker <mhooker@hashicorp.com>"
 ENV PACKER_VERSION=1.0.0
 ENV PACKER_SHA256SUM=ed697ace39f8bb7bf6ccd78e21b2075f53c0f23cdfb5276c380a053a7b906853
 
-RUN apk add --update git bash wget
+RUN apk add --update git bash wget openssl
 
 ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip ./
 ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_SHA256SUMS ./


### PR DESCRIPTION
Packer is unable to parse generated private keys from OpenStack. Builds error with `Error parsing private key: asn1: structure error: superfluous leading zeros in length`.

From my understanding, after reading https://github.com/hashicorp/packer/issues/2526 and https://github.com/golang/go/issues/14145, OpenStack (>= Liberty) generate ssh keys in less secure BER encode. Go will probably never support BER so a workaround was added to Packer where the key gets converted to DER encode and then used.

Adding openssl package to the build enable Packer to convert the key and successfully build images.