### PR TITLE
packer/light: use double-quotes for variable substitution

### DIFF
--- a/packer/Dockerfile-light
+++ b/packer/Dockerfile-light
@@ -9,7 +9,7 @@ RUN apk add --update git bash wget openssl
 ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip ./
 ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_SHA256SUMS ./
 
-RUN sed -i '/packer_${PACKER_VERSION}_linux_amd64.zip/!d' packer_${PACKER_VERSION}_SHA256SUMS
+RUN sed -i "/packer_${PACKER_VERSION}_linux_amd64.zip/!d" packer_${PACKER_VERSION}_SHA256SUMS
 RUN sha256sum -cs packer_${PACKER_VERSION}_SHA256SUMS
 RUN unzip packer_${PACKER_VERSION}_linux_amd64.zip -d /bin
 RUN rm -f packer_${PACKER_VERSION}_linux_amd64.zip


### PR DESCRIPTION
Fixes #38 

Simply using double quotes here fixes the issue. I'm now able to successfully build the image locally.