### PR TITLE
Add TF_RELEASE env var.

### DIFF
--- a/terraform/Dockerfile-full
+++ b/terraform/Dockerfile-full
@@ -6,6 +6,7 @@ ENV TERRAFORM_VERSION=0.10.0
 RUN apk add --update git bash openssh
 
 ENV TF_DEV=true
+ENV TF_RELEASE=true
 
 WORKDIR $GOPATH/src/github.com/hashicorp/terraform
 RUN git clone https://github.com/hashicorp/terraform.git ./ && \


### PR DESCRIPTION
This keeps us from getting the "dirty"/ `-dev` appended to the version.