### PR TITLE
Update the readme to include working examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # docker-hub-images
 Automatic builds of container images for Docker Hub
 
-terraform (full) [![](https://badge.imagelayers.io/timfallmk/terraform:latest.svg)](https://imagelayers.io/?images=timfallmk/terraform:latest 'Get your own badge on imagelayers.io')
+terraform (full) [![](https://badge.imagelayers.io/hashicorp/terraform:latest.svg)](https://imagelayers.io/?images=hashicorp/terraform:latest 'Get your own badge on imagelayers.io')
 
 terraform (light)
-[![](https://badge.imagelayers.io/timfallmk/terraform:light.svg)](https://imagelayers.io/?images=timfallmk/terraform:light 'Get your own badge on imagelayers.io')
+[![](https://badge.imagelayers.io/hashicorp/terraform:light.svg)](https://imagelayers.io/?images=hashicorp/terraform:light 'Get your own badge on imagelayers.io')
 
 packer (full)
-[![](https://badge.imagelayers.io/timfallmk/packer-auto:build.svg)](https://imagelayers.io/?images=timfallmk/packer-auto:build 'Get your own badge on imagelayers.io')
+[![](https://badge.imagelayers.io/hashicorp/packer-auto:build.svg)](https://imagelayers.io/?images=hashicorp/packer-auto:build 'Get your own badge on imagelayers.io')
 
 packer (light)
-[![](https://badge.imagelayers.io/timfallmk/packer-auto:light.svg)](https://imagelayers.io/?images=timfallmk/packer-auto:light 'Get your own badge on imagelayers.io')
+[![](https://badge.imagelayers.io/hashicorp/packer-auto:light.svg)](https://imagelayers.io/?images=hashicorp/packer-auto:light 'Get your own badge on imagelayers.io')

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -2,6 +2,7 @@
 ### Usage
 This repository automatically builds containers for using the [`terraform`](https://terraform.io) command line program. It contains two distinct varieties of build, a `light` version, which just contains the binary, and a `full` version while compiles the binary from source inside the container before exposing it for use. Which you want will depend on use.
 
+
 ##### `light` (default)
 
 The `light` version of this container will copy the current stable version of the binary into the container, and set it for use as the default entrypoint. This will be the best option for most uses, and if you are just looking to run the binary from a container. The `latest` tag also points to this version.
@@ -12,8 +13,15 @@ docker run -i -t hashicorp/terraform:light <command>
 ```
 
 For example:
+Initialize the plugins (You will only need to do this once)
+
 ```shell
-docker run -i -t hashicorp/terraform:light plan main.tf
+docker run -i -t -v $(pwd):/app/ -w /app/ hashicorp/terraform:light init 
+```
+
+
+```shell
+docker run -i -t -v $(pwd):/app/ -w /app/ hashicorp/terraform:light plan
 ```
 
 ##### `full`
@@ -21,9 +29,15 @@ The `full` version of this container contains all of the source code found in th
 
 You can use this version with the following:
 ```shell
-docker run -i -t hashicorp/terraform:full <command>
+docker run -i -t -v $(pwd):/app/ -w /app/ hashicorp/terraform:full <command>
 ```
+
 For example:
+Initialize the plugins (You will only need to do this once)
 ```shell
-docker run -i -t hashicorp/terraform:full plan main.tf
+docker run -i -t -v $(pwd):/app/ -w /app/ hashicorp/terraform:full init 
+```
+
+```shell
+docker run -i -t -v $(pwd):/app/ -w /app/ hashicorp/terraform:full plan main.tf
 ```


### PR DESCRIPTION
With the 0.10.0 plugin changes, you will need to preserve state
between runs (to keep the .terraform directory with plugins)

So include the mounted volume in the examples (so we maintain
copy and pasteable instructions that just work)

Update the working directory because there aren't clear instructions
on which directory the files should get added to which results in confusion

This should also fix #8 