### PR TITLE
add label, change from update to no-cache

### DIFF
--- a/packer/Dockerfile
+++ b/packer/Dockerfile
@@ -1,2 +1,2 @@
 FROM golang:onbuild
-MAINTAINER "Tim Fall <tim@hashicorp.com>"
+LABEL maintainer "Tim Fall <tim@hashicorp.com>"

--- a/packer/Dockerfile-full
+++ b/packer/Dockerfile-full
@@ -1,9 +1,9 @@
 FROM golang:alpine
-MAINTAINER "Matt Hooker <mhooker@hashicorp.com>"
+LABEL maintainer "Matt Hooker <mhooker@hashicorp.com>"
 
 ENV PACKER_DEV=1
 
-RUN apk add --update git bash openssl
+RUN apk add --no-cache git bash openssl
 RUN go get github.com/mitchellh/gox
 RUN go get github.com/hashicorp/packer
 

--- a/packer/Dockerfile-light
+++ b/packer/Dockerfile-light
@@ -1,10 +1,10 @@
 FROM alpine:latest
-MAINTAINER "Matt Hooker <mhooker@hashicorp.com>"
+LABEL maintainer "Matt Hooker <mhooker@hashicorp.com>"
 
 ENV PACKER_VERSION=1.0.3
 ENV PACKER_SHA256SUM=0e10169ef9cf3fd55dcc9dc213b9995170f7712e8a162ca2f5109d62bfbe7529
 
-RUN apk add --update git bash wget openssl
+RUN apk add --no-cache git bash wget openssl
 
 ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip ./
 ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_SHA256SUMS ./

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,2 +1,2 @@
 FROM golang:onbuild
-MAINTAINER "HashiCorp Terraform Team <terraform@hashicorp.com>"
+LABEL maintainer "HashiCorp Terraform Team <terraform@hashicorp.com>"

--- a/terraform/Dockerfile-full
+++ b/terraform/Dockerfile-full
@@ -1,9 +1,9 @@
 FROM golang:alpine
-MAINTAINER "HashiCorp Terraform Team <terraform@hashicorp.com>"
+LABEL maintainer "HashiCorp Terraform Team <terraform@hashicorp.com>"
 
 ENV TERRAFORM_VERSION=0.10.0
 
-RUN apk add --update git bash openssh
+RUN apk add --no-cache git bash openssh
 
 ENV TF_DEV=true
 ENV TF_RELEASE=true

--- a/terraform/Dockerfile-light
+++ b/terraform/Dockerfile-light
@@ -1,10 +1,10 @@
 FROM alpine:latest
-MAINTAINER "HashiCorp Terraform Team <terraform@hashicorp.com>"
+LABEL maintainer "HashiCorp Terraform Team <terraform@hashicorp.com>"
 
 ENV TERRAFORM_VERSION=0.10.0
 ENV TERRAFORM_SHA256SUM=f991039e3822f10d6e05eabf77c9f31f3831149b52ed030775b6ec5195380999
 
-RUN apk add --update git curl openssh && \
+RUN apk add --no-cache git curl openssh && \
     curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     echo "${TERRAFORM_SHA256SUM}  terraform_${TERRAFORM_VERSION}_linux_amd64.zip" > terraform_${TERRAFORM_VERSION}_SHA256SUMS && \
     sha256sum -cs terraform_${TERRAFORM_VERSION}_SHA256SUMS && \


### PR DESCRIPTION
i changed the maintainer to label, since the former is deprecated.
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

i also changed the update instruction to no-cache, since we don't need the cached repo files later.

greetz,

Benjamin