### PR TITLE
Build lighter packer images with less layers

### DIFF
--- a/packer/Dockerfile-light
+++ b/packer/Dockerfile-light
@@ -4,14 +4,11 @@ MAINTAINER "The Packer Team <packer@hashicorp.com>"
 ENV PACKER_VERSION=1.1.2
 ENV PACKER_SHA256SUM=7e315a6110333d9d4269ac2ec5c68e663d82a4575d3e853996a976875612724b
 
-RUN apk add --update git bash wget openssl
-
-ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip ./
-ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_SHA256SUMS ./
-
-RUN sed -i '/.*linux_amd64.zip/!d' packer_${PACKER_VERSION}_SHA256SUMS
-RUN sha256sum -cs packer_${PACKER_VERSION}_SHA256SUMS
-RUN unzip packer_${PACKER_VERSION}_linux_amd64.zip -d /bin
-RUN rm -f packer_${PACKER_VERSION}_linux_amd64.zip
+RUN apk add --update git curl openssh && \
+    curl https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip > packer_${PACKER_VERSION}_linux_amd64.zip && \
+    echo "${PACKER_SHA256SUM}  packer_${PACKER_VERSION}_linux_amd64.zip" > packer_${PACKER_VERSION}_SHA256SUMS && \
+    sha256sum -cs packer_${PACKER_VERSION}_SHA256SUMS && \
+    unzip packer_${PACKER_VERSION}_linux_amd64.zip -d /bin && \
+    rm -f packer_${PACKER_VERSION}_linux_amd64.zip
 
 ENTRYPOINT ["/bin/packer"]


### PR DESCRIPTION
I just found your Docker image hashicorp/packer, thanks for that!

I had a closer look and compared it to the terraform image which is smaller. So I removed the ADD instructions that produce layers that cannot be removed.

```
$ docker run stefanscherer/winspector hashicorp/packer:light
Retrieving information about source image hashicorp/packer:light
Image name: hashicorp/packer
Tag: light
Number of layers: 7
Schema version: 2
Architecture: amd64
Created: 2017-11-15T22:14:57.240149812Z with Docker 17.06.1-ce on linux undefined
Sizes of layers:
  sha256:b56ae66c29370df48e7377c8f9baa744a3958058a766793f821dadcb144a4647 - 1991435 byte
  sha256:45aa596d70faa9c8a6410b545bb20e30abff39fcb8413a1a1553fdf4645a5f32 - 15073725 byte
  sha256:84300587de40ce6e1062129c11bfd5fe9d8d7c36084434a7181abcaf98b78202 - 16318202 byte
  sha256:a4aacf6429906b813242136e52e718ea5bb999e3d71485178e21a8ffc741af29 - 772 byte
  sha256:bf10f12f378ab587fba96360ac994ad111b656e35977657149af04572c499983 - 185 byte
  sha256:1580b1df4c2c9572a98e5eb7af531e0857261ab628fdf01f3e5ce2e3871e68c0 - 16743910 byte
  sha256:8b2fdd755709f8dbe7f7c915ecd1da0263a18a77c545ca0f7f32d1473d14b64f - 119 byte
Total size (including Windows base layers): 50128348 byte
Application size (w/o Windows base layers): 50128348 byte
```

This PR reduces the image size from 50 MB to 33 MB

```
$ docker run stefanscherer/winspector stefanscherer/packer:1.1.2
Retrieving information about source image stefanscherer/packer:1.1.2
Image name: stefanscherer/packer
Tag: 1.1.2
Number of layers: 2
Schema version: 2
Architecture: amd64
Created: 2017-11-18T08:59:20.4549927Z with Docker 17.09.0-ce on linux undefined
Sizes of layers:
  sha256:88286f41530e93dffd4b964e1db22ce4939fffa4a4c665dab8591fbab03d4926 - 1990402 byte
  sha256:efe402a4c18bcda6bc62f8b1d6eee414a60636282507e1388c2a21975d4b28aa - 30555050 byte
Total size (including Windows base layers): 32545452 byte
Application size (w/o Windows base layers): 32545452 byte
```
