### PR TITLE
Add multi-stage build for packer image

### DIFF
--- a/packer/Dockerfile-light
+++ b/packer/Dockerfile-light
@@ -14,4 +14,7 @@ RUN sha256sum -cs packer_${PACKER_VERSION}_SHA256SUMS
 RUN unzip packer_${PACKER_VERSION}_linux_amd64.zip -d /bin
 RUN rm -f packer_${PACKER_VERSION}_linux_amd64.zip
 
+FROM alpine:latest
+COPY --from=0 /bin/packer /bin/packer
+
 ENTRYPOINT ["/bin/packer"]


### PR DESCRIPTION
As an alternative to #49 (or in combination) using a multi-stage build just copies the packer binary into a fresh alpine image.

This reduces the Docker image size from 50 MB ( or 33 MB in PR #49 ) down to 19 MB

```
$ docker run stefanscherer/winspector stefanscherer/packer:1.1.2-alpine
Retrieving information about source image stefanscherer/packer:1.1.2-alpine
Image name: stefanscherer/packer
Tag: 1.1.2-alpine
Number of layers: 2
Schema version: 2
Architecture: amd64
Created: 2017-11-18T09:12:57.5633675Z with Docker 17.09.0-ce on linux undefined
Sizes of layers:
  sha256:88286f41530e93dffd4b964e1db22ce4939fffa4a4c665dab8591fbab03d4926 - 1990402 byte
  sha256:5b2b84c7d4bb92ca428b97ee25d22cb1737d0eee9e243707a2e5a08aac45a1fe - 16743913 byte
Total size (including Windows base layers): 18734315 byte
Application size (w/o Windows base layers): 18734315 byte
```

We could go down further and use a scratch image in the last stage and maybe copy the CA certs into the empty image as well and what else is needed. I ended up in a (to be honest more ugly) Dockerfile that creates a 17 MB image on Docker Hub. But then no other commands are available in that image.

