### PR TITLE
packer and terraform images: install make, curl and curl-dev

### DIFF
--- a/packer/Dockerfile-full
+++ b/packer/Dockerfile-full
@@ -3,7 +3,7 @@ MAINTAINER "The Packer Team <packer@hashicorp.com>"
 
 ENV PACKER_DEV=1
 
-RUN apk add --update git bash openssl
+RUN apk add --update git bash openssl make curl curl-dev
 RUN go get github.com/mitchellh/gox
 RUN go get github.com/hashicorp/packer
 

--- a/packer/Dockerfile-light
+++ b/packer/Dockerfile-light
@@ -4,7 +4,7 @@ MAINTAINER "The Packer Team <packer@hashicorp.com>"
 ENV PACKER_VERSION=1.2.0
 ENV PACKER_SHA256SUM=d1b0fcc4e66dfe4919c25752d028a4e4466921bf0e3f75be3bbf1c85082e8040
 
-RUN apk add --update git bash wget openssl
+RUN apk add --update git bash wget openssl make curl curl-dev
 
 ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip ./
 ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_SHA256SUMS ./

--- a/terraform/Dockerfile-full
+++ b/terraform/Dockerfile-full
@@ -3,7 +3,7 @@ MAINTAINER "HashiCorp Terraform Team <terraform@hashicorp.com>"
 
 ENV TERRAFORM_VERSION=0.10.0
 
-RUN apk add --update git bash openssh
+RUN apk add --update git bash openssh make curl curl-dev
 
 ENV TF_DEV=true
 ENV TF_RELEASE=true

--- a/terraform/Dockerfile-light
+++ b/terraform/Dockerfile-light
@@ -4,7 +4,7 @@ MAINTAINER "HashiCorp Terraform Team <terraform@hashicorp.com>"
 ENV TERRAFORM_VERSION=0.10.0
 ENV TERRAFORM_SHA256SUM=f991039e3822f10d6e05eabf77c9f31f3831149b52ed030775b6ec5195380999
 
-RUN apk add --update git make curl curl-dev openssh && \
+RUN apk add --update git bash make curl curl-dev openssh && \
     curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     echo "${TERRAFORM_SHA256SUM}  terraform_${TERRAFORM_VERSION}_linux_amd64.zip" > terraform_${TERRAFORM_VERSION}_SHA256SUMS && \
     sha256sum -cs terraform_${TERRAFORM_VERSION}_SHA256SUMS && \

--- a/terraform/Dockerfile-light
+++ b/terraform/Dockerfile-light
@@ -4,7 +4,7 @@ MAINTAINER "HashiCorp Terraform Team <terraform@hashicorp.com>"
 ENV TERRAFORM_VERSION=0.10.0
 ENV TERRAFORM_SHA256SUM=f991039e3822f10d6e05eabf77c9f31f3831149b52ed030775b6ec5195380999
 
-RUN apk add --update git curl openssh && \
+RUN apk add --update git make curl curl-dev openssh && \
     curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     echo "${TERRAFORM_SHA256SUM}  terraform_${TERRAFORM_VERSION}_linux_amd64.zip" > terraform_${TERRAFORM_VERSION}_SHA256SUMS && \
     sha256sum -cs terraform_${TERRAFORM_VERSION}_SHA256SUMS && \


### PR DESCRIPTION
Terraform and packer commands can get long and complicated and chaining more than a single call may also be necessary.
To help with reproducibility and consistency across large teams and multiple environments, these commands are often written in makefiles and `make` becomes a tool indispensable for running packer and terraform in complex environments. In addition, running identical commands from a makefile across a set of possible environment usually requires detecting such environment and `curl` is also a popular way (e.g: on AWS) of detecting where things are being run.

This change proposes installing make, curl and curl-dev in all terraform and packer light+full docker images. The overhead is little and the usability of these images in richer environments greatly augmented.

To run `make`, the caller will have to override the docker entrypoint using the `--entrypoint` option, so there is no need, at least for now, to change the `ENTRYPOINT` command in the dockerfiles.