### PR TITLE
Add libc6-compat for terraform plugins dependency issues

### DIFF
--- a/terraform/Dockerfile-full
+++ b/terraform/Dockerfile-full
@@ -3,7 +3,7 @@ MAINTAINER "HashiCorp Terraform Team <terraform@hashicorp.com>"
 
 ENV TERRAFORM_VERSION=0.10.0
 
-RUN apk add --update git bash openssh
+RUN apk add --update git bash openssh libc6-compat
 
 ENV TF_DEV=true
 ENV TF_RELEASE=true

--- a/terraform/Dockerfile-light
+++ b/terraform/Dockerfile-light
@@ -4,7 +4,7 @@ MAINTAINER "HashiCorp Terraform Team <terraform@hashicorp.com>"
 ENV TERRAFORM_VERSION=0.10.0
 ENV TERRAFORM_SHA256SUM=f991039e3822f10d6e05eabf77c9f31f3831149b52ed030775b6ec5195380999
 
-RUN apk add --update git curl openssh && \
+RUN apk add --update git curl openssh libc6-compat && \
     curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     echo "${TERRAFORM_SHA256SUM}  terraform_${TERRAFORM_VERSION}_linux_amd64.zip" > terraform_${TERRAFORM_VERSION}_SHA256SUMS && \
     sha256sum -cs terraform_${TERRAFORM_VERSION}_SHA256SUMS && \


### PR DESCRIPTION
I had the same issue than [issue#56](https://github.com/hashicorp/docker-hub-images/issues/56) and I found that I was missing a glibc dependency which could easily be fixed by installing 'libc6-compat'.
I think this PR can improve the plugins UX when using this docker image
