### PR TITLE
Delete apk cache to decrease the image size

### DIFF
--- a/terraform/Dockerfile-light
+++ b/terraform/Dockerfile-light
@@ -5,10 +5,12 @@ ENV TERRAFORM_VERSION=0.10.0
 ENV TERRAFORM_SHA256SUM=f991039e3822f10d6e05eabf77c9f31f3831149b52ed030775b6ec5195380999
 
 RUN apk add --update git curl openssh && \
+    rm -rf /var/cache/apk/* && \
     curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     echo "${TERRAFORM_SHA256SUM}  terraform_${TERRAFORM_VERSION}_linux_amd64.zip" > terraform_${TERRAFORM_VERSION}_SHA256SUMS && \
     sha256sum -cs terraform_${TERRAFORM_VERSION}_SHA256SUMS && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin && \
-    rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+    rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+        terraform_${TERRAFORM_VERSION}_SHA256SUMS
 
 ENTRYPOINT ["/bin/terraform"]


### PR DESCRIPTION
With this, the final image size should decrease about 1.2MB.