### PR TITLE
Change ENTRYPOINT to CMD for Terraform

### DIFF
--- a/terraform/Dockerfile-full
+++ b/terraform/Dockerfile-full
@@ -14,4 +14,4 @@ RUN git clone https://github.com/hashicorp/terraform.git ./ && \
     /bin/bash scripts/build.sh
 
 WORKDIR $GOPATH
-ENTRYPOINT ["terraform"]
+CMD ["terraform"]

--- a/terraform/Dockerfile-light
+++ b/terraform/Dockerfile-light
@@ -11,4 +11,4 @@ RUN apk add --update git curl openssh && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin && \
     rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
-ENTRYPOINT ["/bin/terraform"]
+CMD ["/bin/terraform"]


### PR DESCRIPTION
This PR changes the Terraform `Dockerfile`'s to use `CMD` instead of `ENTRYPOINT`. This is how a majority of the official Docker images are designed. This design comes from a set of guidelines that have been put into place by the core Docker team for official images. You can find these guidelines here: https://github.com/docker-library/official-images#consistency

In our case, a recent plugin update has caused Jenkins to now follow this design convention more closely. We have already forked the Terraform image to workaround the problem for now, but it would be good for the Terraform (and Hashicorp) images to be updated to match this convention. An example of this Jenkins change can be found here: https://issues.jenkins-ci.org/browse/JENKINS-49446