### PR TITLE
Change ENTRYPOINT to CMD for Packer

### DIFF
--- a/packer/Dockerfile-full
+++ b/packer/Dockerfile-full
@@ -12,4 +12,4 @@ WORKDIR $GOPATH/src/github.com/hashicorp/packer
 RUN /bin/bash scripts/build.sh
 
 WORKDIR $GOPATH
-ENTRYPOINT ["bin/packer"]
+CMD ["bin/packer"]

--- a/packer/Dockerfile-light
+++ b/packer/Dockerfile-light
@@ -14,4 +14,4 @@ RUN sha256sum -cs packer_${PACKER_VERSION}_SHA256SUMS
 RUN unzip packer_${PACKER_VERSION}_linux_amd64.zip -d /bin
 RUN rm -f packer_${PACKER_VERSION}_linux_amd64.zip
 
-ENTRYPOINT ["/bin/packer"]
+CMD ["/bin/packer"]


### PR DESCRIPTION
This PR changes the Packer `Dockerfile`'s to use `CMD` instead of `ENTRYPOINT`. This is how a majority of the official Docker images are designed. This design comes from a set of guidelines that have been put into place by the core Docker team for official images. You can find these guidelines here: https://github.com/docker-library/official-images#consistency

In our case, a recent plugin update has caused Jenkins to now follow this design convention more closely. We have already forked the Packer image to workaround the problem for now, but it would be good for the Packer (and Hashicorp) images to be updated to match this convention. An example of this Jenkins change can be found here: https://issues.jenkins-ci.org/browse/JENKINS-49446