### PR TITLE
Use the local sha256hash

### DIFF
--- a/packer/Dockerfile-light
+++ b/packer/Dockerfile-light
@@ -9,8 +9,7 @@ RUN apk add --update git bash wget openssl
 ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip ./
 ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_SHA256SUMS ./
 
-RUN sed -i '/.*linux_amd64.zip/!d' packer_${PACKER_VERSION}_SHA256SUMS
-RUN sha256sum -cs packer_${PACKER_VERSION}_SHA256SUMS
+RUN echo "${PACKER_SHA256SUM}  packer_${PACKER_VERSION}_linux_amd64.zip" | sha256sum -c -
 RUN unzip packer_${PACKER_VERSION}_linux_amd64.zip -d /bin
 RUN rm -f packer_${PACKER_VERSION}_linux_amd64.zip
 


### PR DESCRIPTION
Forgive me if I'm being a plonker, but doesn't it make more sense to use the locally stored sha256hash to verify the .zip file?

If the remote file repo has been compromised then it makes sense that the nefarious individual involved might also alter the hash file to match their new version of the file.

If you're only protecting against corrupt downloads, then admittedly, the original method would suffice. 