### PR TITLE
update maintainer label on dockerfile light

### DIFF
--- a/packer/Dockerfile-light
+++ b/packer/Dockerfile-light
@@ -1,5 +1,5 @@
 FROM alpine:latest
-MAINTAINER "The Packer Team <packer@hashicorp.com>"
+LABEL maintainer="The Packer Team <packer@hashicorp.com>"
 
 ENV PACKER_VERSION=1.6.2
 ENV PACKER_SHA256SUM=089fc9885263bb283f20e3e7917f85bb109d9335f24d59c81e6f3a0d4a96a608


### PR DESCRIPTION
This brings the Dockerfile-light up to date with the other two Dockerfiles by replacing the [deprecated `MAINTAINER`](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated) instruction with `LABEL maintainer`.