### PR TITLE
add xorriso to allow for iso creation

### DIFF
--- a/packer/Dockerfile-full
+++ b/packer/Dockerfile-full
@@ -3,7 +3,7 @@ LABEL maintainer="The Packer Team <packer@hashicorp.com>"
 
 ENV PACKER_DEV=1
 
-RUN apk add --no-cache git bash openssl ca-certificates
+RUN apk add --no-cache git bash openssl ca-certificates xorriso
 RUN go get github.com/mitchellh/gox
 RUN go get github.com/hashicorp/packer
 

--- a/packer/Dockerfile-light
+++ b/packer/Dockerfile-light
@@ -4,7 +4,7 @@ LABEL maintainer="The Packer Team <packer@hashicorp.com>"
 ENV PACKER_VERSION=1.6.4
 ENV PACKER_SHA256SUM=a20ec68e9eb6e1d6016481003f705babbecc28e234f8434f3a35f675cb200ea8
 
-RUN apk add --update git bash wget openssl
+RUN apk add --update git bash wget openssl xorriso
 
 ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip ./
 ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_SHA256SUMS ./


### PR DESCRIPTION
With vsphere-iso (and others) now allowing for cd upload using `cd_files`, the docker container needed the ability to create isos. I've added in `xorriso` based on the error received.


```
==> vm-windows-2016-20201001134106: Creating CD disk...
2020/10/02 19:06:16 packer-builder-vsphere-iso plugin: CD path: /tmp/packer034808979.iso
2020/10/02 19:06:16 packer-builder-vsphere-iso plugin: Wrote 11104 bytes to files/2016/Autounattend.xml
...
2020/10/02 19:06:16 packer-builder-vsphere-iso plugin: Deleting CD disk: /tmp/packer034808979.iso
2020/10/02 19:06:16 [INFO] (telemetry) ending vsphere-iso
==> Wait completed after 165 milliseconds 907 microseconds
2020/10/02 19:06:16 machine readable: error-count []string{"1"}
==> Some builds didn't complete successfully and had errors:
2020/10/02 19:06:16 machine readable: vm-windows-2016-20201001134106,error []string{"could not find a supported CD ISO creation command (the supported commands are: xorriso, mkisofs, hdiutil, oscdimg)"}
==> Builds finished but no artifacts were created.
2020/10/02 19:06:16 [INFO] (telemetry) Finalizing.
Build 'vm-windows-2016-20201001134106' errored after 165 milliseconds 883 microseconds: could not find a supported CD ISO creation command (the supported commands are: xorriso, mkisofs, hdiutil, oscdimg)
```