### PR TITLE
Really light Docker image

### DIFF
--- a/packer/Dockerfile-light
+++ b/packer/Dockerfile-light
@@ -6,12 +6,16 @@ ENV PACKER_SHA256SUM=8513c3679d51141c39da3d95c691fcfc4b2ccc20e96ac5244b58b98899d
 
 RUN apk add --update git bash wget openssl
 
-ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip ./
-ADD https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_SHA256SUMS ./
+RUN wget --progress=bar:force \
+      -O packer_${PACKER_VERSION}_SHA256SUMS \
+      https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_SHA256SUMS \
+    && sed -i '/.*linux_amd64.zip/!d' packer_${PACKER_VERSION}_SHA256SUMS \
+    && sha256sum -cs packer_${PACKER_VERSION}_SHA256SUMS
 
-RUN sed -i '/.*linux_amd64.zip/!d' packer_${PACKER_VERSION}_SHA256SUMS
-RUN sha256sum -cs packer_${PACKER_VERSION}_SHA256SUMS
-RUN unzip packer_${PACKER_VERSION}_linux_amd64.zip -d /bin
-RUN rm -f packer_${PACKER_VERSION}_linux_amd64.zip
+RUN wget --progress=bar:force \
+      -O packer_${PACKER_VERSION}_linux_amd64.zip \
+      https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip \
+    && unzip packer_${PACKER_VERSION}_linux_amd64.zip -d /bin \
+    && rm -f packer_${PACKER_VERSION}_linux_amd64.zip
 
 ENTRYPOINT ["/bin/packer"]


### PR DESCRIPTION
As you can see in image layers:  
https://hub.docker.com/layers/hashicorp/packer/light/images/sha256-3e406eccb9e7c9a34d0c4fc09dd2a6e3ad9355457fa5301a3587d4c5b569b923?context=explore  
the `ADD` instructions add extra layer with packer distribution zip. 

With this PR, light Docker image size is divide by 2